### PR TITLE
Release 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This package adds the node "Query Game Server" that uses the NPM package [GameDi
 
 You can pass the server type, host, and port on the input message or define them on the node (settings defined on the node will override msg values).
 
-[Click here](https://github.com/gamedig/node-gamedig#return-value) if you want more information about what this library parses and standardizes from the server response.
+You can also specify manual GameDig options using `msg.options` as an input. This will override any other options. For example: you can set `msg.options.guildId` that is required for querying Discord servers.
+
+Visit the [GameDig GitLab page](https://github.com/gamedig/node-gamedig#return-value) if you want more information about what this library parses and standardizes from the server response.
 
 ### Usage Examples
 - #### Inserting query data into InfluxDB and using Grafana to view results

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # node-red-contrib-gamedig
 
-Query for the status of most game/voice servers using Node-RED.
+Query for server information of most game/voice servers using Node-RED.
 
 This package adds the node "Query Game Server" that uses the NPM package [GameDig](https://www.npmjs.com/package/gamedig) to query if a server is online or not and if so returns the data of the server.
 
 You can pass the server type, host, and port on the input message or define them on the node (settings defined on the node will override msg values).
 
+[Click here](https://github.com/gamedig/node-gamedig#return-value) if you want more information about what this library parses and standardizes from the server response.
+
 ### Usage Examples
-#### Inserting query data into InfluxDB and using Grafana to view results
-![Flow Preview](https://skylar.tech/content/images/2019/12/image-2.png)
-I created a post on my website about how to use this node to query gameservers and store the results in InfluxDB. I then give a dashboard in Grafana that can be used to display the data. Check it out here:
-https://skylar.tech/tracking-game-server-statistics-using-node-red-influxdb-and-grafana/
+- #### Inserting query data into InfluxDB and using Grafana to view results
+  ![Flow Preview](https://skylar.tech/content/images/2019/12/image-2.png)
+  I created a post on my website about how to use this node to query gameservers and store the results in InfluxDB. I then give a dashboard in Grafana that can be used to display the data. Check it out here:
+  https://skylar.tech/tracking-game-server-statistics-using-node-red-influxdb-and-grafana/
+
+- #### Automatically restarting servers when unavailable
+  Ever host a server and have it stop responding but the process doesn't crash so it doesn't auto restart? If you pair this with something like [node-red-contrib-dockerode](https://flows.nodered.org/node/node-red-contrib-dockerode) you can automatically restart the container/process if the query fails X times to respond.
 
 ### Other Packages
 

--- a/query-game-server.html
+++ b/query-game-server.html
@@ -11,6 +11,10 @@
             max_attempts:     { value: '' },
             socket_timeout:   { value: '' },
             attempt_timeout:  { value: '' },
+            given_port_only:  { value: '' },
+            ip_family:        { value: '0' },
+            debug:            { value: '' },
+            request_rules:    { value: '' }
         },
         inputs:1,
         outputs:1,
@@ -79,7 +83,7 @@
     </div>
 
     <div class="form-row">
-        <label for="node-input-port"><i class="fa fa-ethernet"></i> Port</label>
+        <label for="node-input-port"><i class="fa fa-server"></i> Port</label>
         <input type="text" id="node-input-port" placeholder="msg.host" />
     </div>
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
@@ -117,11 +121,61 @@
     </div>
 
     <div class="form-row">
-        <label for="node-input-attempt_timeout"><i class="fas fa-cogs"></i> Attempt Timeout</label>
+        <label for="node-input-attempt_timeout"><i class="fa fa-cogs"></i> Attempt Timeout</label>
         <input type="text" id="node-input-attempt_timeout" placeholder="10000" />
     </div>
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
         Milliseconds allowed for an entire query attempt. This timeout is not commonly hit, as the socketTimeout typically fires first.
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-given_port_only"><i class="fa fa-lock"></i> Lock port</label>
+        <input
+                type="checkbox"
+                id="node-input-given_port_only"
+                style="width: auto; vertical-align: top"
+        />
+        <span>
+            Only attempt to query server on given port (default: false).
+        </span>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-debug"><i class="fa fa-bug"></i> Debug mode</label>
+        <input
+                type="checkbox"
+                id="node-input-debug"
+                style="width: auto; vertical-align: top"
+        />
+        <span>
+        Enables massive amounts of debug logging to stdout.
+        </span>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-request_rules" style="vertical-align: top"><i class="fa fa-server"></i> Request rules</label>
+        <div style="width: 50%;display: inline-block;">
+            <input
+                    type="checkbox"
+                    id="node-input-request_rules"
+                    style="width: auto; vertical-align: top"
+            />
+            For many valve games, additional 'rules' may be fetched into the unstable raw field by setting this to true. Beware that this may increase query time and this is for Valve games only.
+        </div>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-ip_family"><i class="fa fa-server"></i> IP Rules</label>
+        <select
+                id="node-input-ip_family"
+                style="width: auto; vertical-align: top">
+            <option value="0">IPv4 and IPv6</option>
+            <option value="4">IPv4</option>
+            <option value="6">IPv6</option>
+        </select>
+    </div>
+    <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
+        IP family/version returned when looking up hostnames via DNS, can be IPv4 and IPv6, IPv4 only or IPv6 only.
     </div>
 
     <h3 id="gamdig-types">Server Types</h3>
@@ -155,7 +209,7 @@
 </script>
 
 <script type="text/html" data-help-name="query-game-server">
-    <p>Query most Game/Voice server's using the <a href="https://github.com/gamedig/node-gamedig" target="_blank">GameDig</a> library.</p>
+    <p>Query most Game/Voice server's using the <a href="https://github.com/gamedig/node-gamedig" target="_blank">GameDig</a> library. I recommend visiting the <a href="https://github.com/gamedig/node-gamedig" target="_blank">node-gamedig GitHub page</a> for more documentation.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">
@@ -188,6 +242,26 @@
             msg.attempt_timeout <span class="property-type">integer | null</span>
         </dt>
         <dd>Milliseconds allowed for an entire query attempt. This timeout is not commonly hit, as the socketTimeout typically fires first. Ignored if configured on the node.</dd>
+
+        <dt class="optional">
+            msg.given_port_only <span class="property-type">boolean</span>
+        </dt>
+        <dd>Only attempt to query server on given port. Ignored if configured on the node.</dd>
+
+        <dt class="optional">
+            msg.ip_family <span class="property-type">number</span>
+        </dt>
+        <dd>IP family/version returned when looking up hostnames via DNS, can be 0 (IPv4 and IPv6), 4 (IPv4 only) or 6 (IPv6 only). (default 0).</dd>
+
+        <dt class="optional">
+            msg.debug <span class="property-type">boolean</span>
+        </dt>
+        <dd>Enables massive amounts of debug logging to stdout. (default false)</dd>
+
+        <dt class="optional">
+            msg.request_rules <span class="property-type">boolean</span>
+        </dt>
+        <dd>For many valve games, additional 'rules' may be fetched into the unstable raw field by setting this to true. Beware that this may increase query time and this is for Valve games only.</dd>
     </dl>
 
     <h3>Outputs</h3>

--- a/query-game-server.html
+++ b/query-game-server.html
@@ -32,20 +32,38 @@
             return 'Query Game Server';
         },
         oneditprepare: function() {
+            let server_types = null;
+
             $.getJSON('/gamedig/types', function(data) {
-                let html = '<table>' +
-                    '<thead id="query-game-server-types-table"><tr><td><strong>Type</strong></td><td><strong>Name</strong></td><td><strong>Protocol</strong></td></tr></thead>' +
-                    '<tbody id="query-game-server-type-rows">';
-                for(let game of data) {
-                    html += "<tr class=\"query-game-server-type-row\">" +
-                        "<td>"+game['type']+"</td>" +
-                        "<td>"+game['name']+"</td>" +
-                        "<td>"+game['protocol']+"</td>" +
-                        "</tr>";
+                if(data.result !== 'ok' || !data.hasOwnProperty("server_types"))
+                {
+                    console.error("server_types failed to load");
+                    return;
                 }
-                html += '</tbody>' +
-                    '</table>';
-                $("#query-game-server-types").html(html);
+
+                server_types = data.server_types;
+            });
+
+            $("#node-input-server_type").autoComplete({
+                search: function(val) {
+                    if(!server_types) return false; // ignore until we have the types loaded
+
+                    let matches = [];
+                    server_types.forEach(v => {
+                        if (
+                            v.name.toLowerCase().indexOf(val.toLowerCase()) > -1 ||
+                            v.type.toLowerCase().indexOf(val.toLowerCase()) > -1 ||
+                            v.protocol.toLowerCase().indexOf(val.toLowerCase()) > -1
+                        ) {
+                            matches.push({
+                                value: v.type,
+                                label: `${v.name} (${v.type})`,
+                                protocol: v.protocol
+                            });
+                        }
+                    });
+                    return matches;
+                }
             });
         }
     });
@@ -68,10 +86,10 @@
 
     <div class="form-row">
         <label for="node-input-server_type"><i class="fa fa-cube"></i> Server Type</label>
-        <input type="text" id="node-input-server_type">
+        <input type="text" id="node-input-server_type" placeholder="msg.server_type">
     </div>
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
-        View server types <a href="#gamdig-types" style="color:#0000EE;text-decoration: underline;">below</a>.
+        Recommend visiting the <a href="https://github.com/gamedig/node-gamedig#games-list" target="_blank" style="color:#0000EE;text-decoration: underline;">GameDig GitHub page</a> for more information about the server type you are trying to query. Some types require extra setup.
     </div>
 
     <div class="form-row">
@@ -84,7 +102,7 @@
 
     <div class="form-row">
         <label for="node-input-port"><i class="fa fa-server"></i> Port</label>
-        <input type="text" id="node-input-port" placeholder="msg.host" />
+        <input type="text" id="node-input-port" placeholder="msg.port" />
     </div>
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
         Query port for the server (join and query port may differ).
@@ -106,7 +124,7 @@
 
     <div class="form-row">
         <label for="node-input-max_attempts"><i class="fa fa-cogs"></i> Max Attempts</label>
-        <input type="text" id="node-input-max_attempts" placeholder="1" />
+        <input type="text" id="node-input-max_attempts" placeholder="msg.max_attempts (default: 1)" />
     </div>
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
         Number of attempts to query server in case of failure.
@@ -114,7 +132,7 @@
 
     <div class="form-row">
         <label for="node-input-socket_timeout"><i class="fa fa-cogs"></i> Socket Timeout</label>
-        <input type="text" id="node-input-socket_timeout" placeholder="2000" />
+        <input type="text" id="node-input-socket_timeout" placeholder="msg.socket_timeout (default: 2000)" />
     </div>
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
         Milliseconds to wait for a single packet. Beware that increasing this will cause many queries to take longer even if the server is online.
@@ -122,7 +140,7 @@
 
     <div class="form-row">
         <label for="node-input-attempt_timeout"><i class="fa fa-cogs"></i> Attempt Timeout</label>
-        <input type="text" id="node-input-attempt_timeout" placeholder="10000" />
+        <input type="text" id="node-input-attempt_timeout" placeholder="msg.attempt_timeout (default: 10000)" />
     </div>
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
         Milliseconds allowed for an entire query attempt. This timeout is not commonly hit, as the socketTimeout typically fires first.
@@ -177,35 +195,6 @@
     <div style="margin-left: 105px;width: 50%;margin-bottom: 10px;margin-top: -10px;">
         IP family/version returned when looking up hostnames via DNS, can be IPv4 and IPv6, IPv4 only or IPv6 only.
     </div>
-
-    <h3 id="gamdig-types">Server Types</h3>
-    <p>
-        Search available types below.<br>
-        You can also view the list <a href="https://github.com/gamedig/node-gamedig#games-list" target="_blank" style="color:#0000EE;text-decoration: underline;">here</a>.
-    </p>
-
-    <div class="row">
-        <input type="text" id="query-game-server-types-search" placeholder="Search types.." style="margin-bottom: 10px;" />
-    </div>
-    <div id="query-game-server-types"></div>
-    <script type="text/javascript">
-        $("#query-game-server-types-search").on("input", function(e) {
-            let value = $(this).val();
-            if(value.length) {
-                $(".query-game-server-type-row").each(function(i, elem){
-                    console.log('yay', $(elem).text(), value, $(elem).text().indexOf(value));
-                    if($(elem).text().toLowerCase().indexOf(value.toLowerCase()) > -1) {
-                        $(elem).show();
-                    } else {
-                        $(elem).hide();
-                    }
-                });
-                return;
-            }
-
-            $(".query-game-server-type-row").show();
-        });
-    </script>
 </script>
 
 <script type="text/html" data-help-name="query-game-server">

--- a/query-game-server.html
+++ b/query-game-server.html
@@ -14,7 +14,8 @@
             given_port_only:  { value: '' },
             ip_family:        { value: '0' },
             debug:            { value: '' },
-            request_rules:    { value: '' }
+            request_rules:    { value: '' },
+            output_options:   { value: '' }
         },
         inputs:1,
         outputs:1,
@@ -183,6 +184,18 @@
     </div>
 
     <div class="form-row">
+        <label for="node-input-output_options" style="vertical-align: top"><i class="fa fa-server"></i> Output options</label>
+        <div style="width: 50%;display: inline-block;">
+            <input
+                    type="checkbox"
+                    id="node-input-output_options"
+                    style="width: auto; vertical-align: top"
+            />
+            Outputs <code style="white-space: normal;">msg.options</code> as an object that contains all the options used to query the server using GameDig. Note: If you pass <code style="white-space: normal;">msg.options</code> as an input it will override all set options so make sure you unset it if chaining multiple server query nodes together unless that is what you want.
+        </div>
+    </div>
+
+    <div class="form-row">
         <label for="node-input-ip_family"><i class="fa fa-server"></i> IP Rules</label>
         <select
                 id="node-input-ip_family"
@@ -216,6 +229,11 @@
             msg.port <span class="property-type">integer | null</span>
         </dt>
         <dd>Query port of the server. Ignored if configured on the node. Uses default query port for the server type if left empty.</dd>
+
+        <dt class="optional">
+            msg.options <span class="property-type">object | null</span>
+        </dt>
+        <dd>Set additional GameDig options. This overrides all other methods of setting options. Can be used for example to set <code style="white-space: normal;">msg.options.guildId</code> that is required for querying Discord servers.</dd>
 
         <dt class="optional">
             msg.max_attempts <span class="property-type">integer | null</span>
@@ -286,18 +304,8 @@
         <dd>Query port of the server. Ignored if configured on the node.</dd>
 
         <dt>
-            msg.max_attempts <span class="property-type">integer</span>
+            msg.options <span class="property-type">object | undefined</span>
         </dt>
-        <dd>Number of attempts to query server in case of failure. Ignored if configured on the node.</dd>
-
-        <dt>
-            msg.socket_timeout <span class="property-type">integer</span>
-        </dt>
-        <dd>Milliseconds to wait for a single packet. Beware that increasing this will cause many queries to take longer even if the server is online. Ignored if configured on the node.</dd>
-
-        <dt>
-            msg.attempt_timeout <span class="property-type">integer</span>
-        </dt>
-        <dd>Milliseconds allowed for an entire query attempt. This timeout is not commonly hit, as the socketTimeout typically fires first. Ignored if configured on the node.</dd>
+        <dd>Only set if configured to do so. Will return all the options passed to GameDig to query the server.</dd>
     </dl>
 </script>

--- a/query-game-server.js
+++ b/query-game-server.js
@@ -12,6 +12,10 @@ module.exports = function(RED) {
 		this.max_attempts = config.max_attempts || 1;
 		this.socket_timeout = config.socket_timeout || 2000;
 		this.attempt_timeout = config.attempt_timeout || 10000;
+		this.given_port_only = config.given_port_only || false;
+		this.ip_family = config.ip_family || 0;
+		this.debug = config.debug || false;
+		this.request_rules = config.request_rules || false;
         node.on('input', function(msg) {
         	if(node.server_type) {
 				msg.server_type = node.server_type;
@@ -45,13 +49,33 @@ module.exports = function(RED) {
 				msg.attempt_timeout = node.attempt_timeout;
 			}
 
+			if(node.given_port_only) {
+				msg.given_port_only = node.given_port_only;
+			}
+
+			if(node.ip_family) {
+				msg.ip_family = node.ip_family;
+			}
+
+			if(node.debug) {
+				msg.debug = node.debug;
+			}
+
+			if(node.request_rules) {
+				msg.request_rules = node.request_rules;
+			}
+
 			gamedig.query({
 				'type': msg.server_type,
 				'host': msg.host,
 				'port': msg.port,
 				'maxAttempts': msg.max_attempts,
 				'socketTimeout': msg.socket_timeout,
-				'attemptTimeout': msg.attempt_timeout
+				'attemptTimeout': msg.attempt_timeout,
+				'givenPortOnly': msg.given_port_only,
+				'ipFamily': msg.ip_family,
+				'debug': msg.debug,
+				'requestRules': msg.request_rules
 			})
 				.then(function(state) {
 					msg.payload = 'online';

--- a/query-game-server.js
+++ b/query-game-server.js
@@ -108,7 +108,7 @@ module.exports = function(RED) {
 			// so we just use regex to parse the info from the README
 			// this could break so we also reference the gamedig repo
 			let availableTypesContent = fs.readFileSync(require.resolve("gamedig/games.txt"), 'utf-8')
-				results = [];
+				server_types = [];
 
 			availableTypesContent
 				.split(/\r?\n/)
@@ -126,12 +126,15 @@ module.exports = function(RED) {
 					// avp2010|Aliens vs. Predator (2010)|valve|port=27015
 
 					let [game_type, game_name, game_protocol] = line.split('|');
-					results.push({
-						'name': game_type,
+					server_types.push({
+						'name': game_name,
 						'type': game_type,
 						'protocol': game_protocol
 					});
 				});
-			res.json(results);
+			res.json({
+				'result': 'ok',
+				'server_types': server_types
+			});
 		});
 };


### PR DESCRIPTION
Make sure to read the note below about the breaking change and update your flows if you are using the mentioned output variables in existing flows.

Breaking change:
- This node no longer returns `msg.max_attempts`, `msg.socket_timeout`, and `msg.attempt_timeout` by default. Instead see "Output options" mentioned below if you need these variables and make sure you update your existing flows to use the new variable name.

New features/Changes:
- Added all advanced options from GameDig (or at least all the ones specified on the README). Closes #10
   - All of the new advanced options are also available to edit from the UI just like all the other settings.
   - `msg.given_port_only`: boolean - Only attempt to query server on given port. (default false)
   - `msg.ip_family`: number - IP family/version returned when looking up hostnames via DNS, can be 0 (IPv4 and IPv6), 4 (IPv4 only) or 6 (IPv6 only). (default 0)
   - `msg.debug`: boolean - Enables massive amounts of debug logging to stdout. (default false)
   - `msg.request_rules`: boolean - Valve games only. Additional 'rules' may be fetched into the raw field for this protocol if set to true. (default false)
- New option "Output options" that you can enable from config to output `msg.options` object that contains all options we passed to GameDig to query the server.
- You can now pass any option to the underlying GameDig library when querying a server by setting `msg.options` object on the input. Can be used for example to set `msg.options.guildId` that is required for querying Discord servers. Note that this will override even the config settings from the UI.
- Server types are now searchable using autocomplete from the input field rather then searching from the bottom of the config page. Closes #11 

